### PR TITLE
TEL-2723: remove dockerd start-up

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,8 +5,6 @@ env:
 phases:
   install:
     commands:
-      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --iptables=false --storage-driver=overlay2 &
-      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
       - make setup
   build:
     commands:


### PR DESCRIPTION
* it seems that running in the custom build agent negates the need for running SAM in container

Co-authored-by: Vitor Brandao <109226+vitorbrandao@users.noreply.github.com>
